### PR TITLE
change actions/index.js to use own backend

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -12,9 +12,10 @@ export const FETCH_COURSE_POINTS = 'FETCH_COURSE_POINTS';
 export const fetchCoursePoints = () => {
     // actionCreator, joka aina palauttaa actionin (jolla on aina oltava tyyppi)
     // Tämä actionCreator luo AJAX kyselyn ja palauttaa sen tuloksen (payload)
-    const url = TEST_USER.ROOT_URL+'/courses/'+TEST_USER.COURSE_ID+'/users/'+TEST_USER.USER_ID+'/points';
-    const request = axios.get(url, { headers: {'Authorization': TEST_USER.ACCESS_TOKEN }});
+    // const url = TEST_USER.ROOT_URL+'/courses/'+TEST_USER.COURSE_ID+'/users/'+TEST_USER.USER_ID+'/points';
+    // const request = axios.get(url, { headers: {'Authorization': TEST_USER.ACCESS_TOKEN }});
 
+    const request = axios.get("http://student-dashboard-api.herokuapp.com/points");
     return {
         type: 'FETCH_COURSE_POINTS',
         payload: request


### PR DESCRIPTION
Siirretään actions/index.js axios.get-kysely käyttämään omaa backendiä: http://student-dashboard-api.herokuapp.com/points. Toimii ja palauttaa 3 pistettä 24.07.2017 klo 17:55. / jaakko